### PR TITLE
Refine workspace navigator collapsible layout

### DIFF
--- a/rec2pdf-frontend/src/components/WorkspaceNavigator.jsx
+++ b/rec2pdf-frontend/src/components/WorkspaceNavigator.jsx
@@ -81,6 +81,12 @@ export default function WorkspaceNavigator({
   pipelineSelection,
   onAdoptSelection,
 }) {
+  const normalizedSelection = selection || {
+    workspaceId: "",
+    projectId: "",
+    projectName: "",
+    status: "",
+  };
   const [filterName, setFilterName] = useState("");
   const [selectedEntryId, setSelectedEntryId] = useState(null);
   const [previewState, setPreviewState] = useState({
@@ -92,13 +98,26 @@ export default function WorkspaceNavigator({
   });
   const [assigning, setAssigning] = useState(false);
   const previewCache = useRef(new Map());
+  const [expandedPanels, setExpandedPanels] = useState(() => ({
+    navigator: Boolean(normalizedSelection.workspaceId),
+    filters: Boolean((searchTerm || "").trim()) || savedFilters.length > 0,
+    documents: true,
+    inspector: false,
+  }));
 
-  const normalizedSelection = selection || {
-    workspaceId: "",
-    projectId: "",
-    projectName: "",
-    status: "",
+  const togglePanel = (panelKey) => {
+    setExpandedPanels((prev) => ({ ...prev, [panelKey]: !prev[panelKey] }));
   };
+
+  useEffect(() => {
+    if (!normalizedSelection.workspaceId) return;
+    setExpandedPanels((prev) => (prev.navigator ? prev : { ...prev, navigator: true }));
+  }, [normalizedSelection.workspaceId]);
+
+  useEffect(() => {
+    if (!(searchTerm || "").trim()) return;
+    setExpandedPanels((prev) => (prev.filters ? prev : { ...prev, filters: true }));
+  }, [searchTerm]);
 
   const entryGroups = useMemo(() => {
     const groups = new Map();
@@ -258,6 +277,11 @@ export default function WorkspaceNavigator({
     return baseProjects.sort((a, b) => a.name.localeCompare(b.name, "it", { sensitivity: "base" }));
   }, [normalizedSelection.workspaceId, selectedWorkspace, entryGroups]);
 
+  const activeProject = useMemo(() => {
+    if (!normalizedSelection.projectId) return null;
+    return projectCatalog.find((item) => item.key === normalizedSelection.projectId) || null;
+  }, [projectCatalog, normalizedSelection.projectId]);
+
   const statusCatalog = useMemo(() => {
     if (!normalizedSelection.workspaceId) return [];
     if (normalizedSelection.workspaceId === UNASSIGNED_KEY) {
@@ -340,6 +364,18 @@ export default function WorkspaceNavigator({
   }, [filteredEntries, selectedEntryId]);
 
   useEffect(() => {
+    setExpandedPanels((prev) => {
+      if (selectedEntry && !prev.inspector) {
+        return { ...prev, inspector: true };
+      }
+      if (!selectedEntry && prev.inspector) {
+        return { ...prev, inspector: false };
+      }
+      return prev;
+    });
+  }, [selectedEntry]);
+
+  useEffect(() => {
     if (!selectedEntry || !fetchPreview) {
       setPreviewState((prev) => ({ ...prev, loading: false, error: "", markdown: "", mdUrl: "", pdfUrl: "" }));
       return;
@@ -392,20 +428,19 @@ export default function WorkspaceNavigator({
 
   const workspaceAssignment = useMemo(() => {
     if (!selectedWorkspace || normalizedSelection.workspaceId === UNASSIGNED_KEY) return null;
-    const project = projectCatalog.find((item) => item.key === normalizedSelection.projectId) || null;
     return {
       id: selectedWorkspace.id,
       name: selectedWorkspace.name,
       client: selectedWorkspace.client,
       color: selectedWorkspace.color,
-      projectId: project?.id || "",
-      projectName: project ? project.name : normalizedSelection.projectName || "",
-      projectColor: project?.color || selectedWorkspace.color,
+      projectId: activeProject?.id || "",
+      projectName: activeProject ? activeProject.name : normalizedSelection.projectName || "",
+      projectColor: activeProject?.color || selectedWorkspace.color,
       status: normalizedSelection.status || "",
       versioningPolicy: selectedWorkspace.versioningPolicy || null,
       statusCatalog: statusLabels,
     };
-  }, [selectedWorkspace, normalizedSelection.workspaceId, normalizedSelection.projectId, normalizedSelection.projectName, normalizedSelection.status, projectCatalog, statusLabels]);
+  }, [selectedWorkspace, normalizedSelection.workspaceId, normalizedSelection.projectName, normalizedSelection.status, activeProject, statusLabels]);
 
   const selectionProjectKey = normalizedSelection.projectId;
 
@@ -448,9 +483,8 @@ export default function WorkspaceNavigator({
       parts.push({ label: selectedWorkspace.name, color: selectedWorkspace.color, client: selectedWorkspace.client });
     }
     if (selectionProjectKey) {
-      const project = projectCatalog.find((item) => item.key === selectionProjectKey);
-      if (project) {
-        parts.push({ label: project.name, color: project.color });
+      if (activeProject) {
+        parts.push({ label: activeProject.name, color: activeProject.color });
       } else if (normalizedSelection.projectName) {
         parts.push({ label: normalizedSelection.projectName, color: selectedWorkspace?.color || "#6366f1" });
       }
@@ -462,7 +496,7 @@ export default function WorkspaceNavigator({
       parts.push({ label: "Tutti i workspace", color: "#6366f1" });
     }
     return parts;
-  }, [normalizedSelection.workspaceId, normalizedSelection.projectName, normalizedSelection.status, selectedWorkspace, projectCatalog, selectionProjectKey]);
+  }, [normalizedSelection.workspaceId, normalizedSelection.projectName, normalizedSelection.status, selectedWorkspace, selectionProjectKey, activeProject]);
 
   const handleWorkspaceReset = useCallback(() => {
     onSelectionChange?.({ workspaceId: "", projectId: "", projectName: "", status: "" });
@@ -538,493 +572,616 @@ export default function WorkspaceNavigator({
       .finally(() => setAssigning(false));
   }, [onAssignWorkspace, selectedEntry]);
 
+  const workspaceBadgeColor = useMemo(() => {
+    if (normalizedSelection.workspaceId === UNASSIGNED_KEY) return "#52525b";
+    if (selectedWorkspace?.color) return selectedWorkspace.color;
+    return "#6366f1";
+  }, [normalizedSelection.workspaceId, selectedWorkspace]);
+
+  const workspaceBadgeLabel = useMemo(() => {
+    if (normalizedSelection.workspaceId === UNASSIGNED_KEY) return "Non assegnati";
+    if (selectedWorkspace) return selectedWorkspace.name;
+    if (normalizedSelection.workspaceId) return "Workspace selezionato";
+    return "Tutti i workspace";
+  }, [normalizedSelection.workspaceId, selectedWorkspace]);
+
+  const projectBadgeLabel = useMemo(() => {
+    if (!normalizedSelection.projectId) return null;
+    return activeProject?.name || normalizedSelection.projectName || "Progetto selezionato";
+  }, [normalizedSelection.projectId, normalizedSelection.projectName, activeProject]);
+
+  const statusBadgeLabel = useMemo(() => normalizedSelection.status || null, [normalizedSelection.status]);
+
+  const documentsCountLabel = useMemo(() => {
+    const count = filteredEntries.length;
+    if (count === 1) return "1 documento";
+    return `${count} documenti`;
+  }, [filteredEntries.length]);
+
+  const searchActive = useMemo(() => Boolean((searchTerm || "").trim()), [searchTerm]);
+
   return (
-    <div className={classNames("rounded-2xl border shadow-lg p-6", themeStyles?.card)}>
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-1">
+    <div className={classNames("overflow-hidden rounded-2xl border shadow-lg", themeStyles?.card)}>
+      <div className="flex flex-col gap-4 border-b border-zinc-800/60 p-6">
+        <div className="space-y-2">
           <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-indigo-200">
             <Users className="h-4 w-4" /> Workspace Navigator
           </div>
           <p className="text-sm text-zinc-400">
-            Organizza deliverable per cliente, progetto e stato, con anteprime istantanee e indicatori di completezza.
+            Mantieni la vista essenziale e apri solo le aree di lavoro che ti servono: seleziona workspace, applica filtri e analizza i deliverable quando vuoi.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            onClick={onRefresh}
-            className={classNames(
-              "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
-              themeStyles?.input,
-              themeStyles?.input_hover,
-              loading && "opacity-70"
-            )}
-            disabled={loading}
-          >
-            <RefreshCw className={classNames("h-3.5 w-3.5", loading && "animate-spin")}
-            /> Aggiorna
-          </button>
-          <button
-            onClick={onAdoptSelection}
-            className={classNames(
-              "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
-              themeStyles?.button,
-              pipelineAligned && "ring-2 ring-emerald-400/70"
-            )}
-            disabled={!onAdoptSelection}
-          >
-            <Sparkles className="h-3.5 w-3.5" /> Usa nel form pipeline
-          </button>
-        </div>
-      </div>
-
-      <div className="mt-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 min-w-[200px]">
-          <FilterIcon className="absolute left-3 top-2.5 h-4 w-4 text-zinc-500" />
-          <input
-            value={searchTerm}
-            onChange={(event) => onSearchChange?.(event.target.value)}
-            placeholder="Filtra per titolo, cliente, progetto o stato"
-            className={classNames(
-              "w-full rounded-xl border bg-transparent px-9 py-2 text-sm outline-none",
-              themeStyles?.input
-            )}
-          />
-          {searchTerm && (
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
             <button
-              onClick={() => onSearchChange?.("")}
-              className="absolute right-2 top-2 rounded-lg px-2 py-1 text-xs text-zinc-400 hover:text-zinc-200"
+              type="button"
+              onClick={() => togglePanel("navigator")}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition",
+                expandedPanels.navigator
+                  ? "border-indigo-500/50 bg-indigo-500/10 text-indigo-100"
+                  : "border-zinc-700 bg-transparent text-zinc-300 hover:border-indigo-400/50 hover:text-indigo-100"
+              )}
             >
-              Pulisci
+              <Users className="h-3.5 w-3.5" />
+              {expandedPanels.navigator ? "Compatta navigator" : "Apri navigator"}
             </button>
+            <button
+              type="button"
+              onClick={() => togglePanel("filters")}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition",
+                expandedPanels.filters
+                  ? "border-zinc-600 bg-zinc-800/70 text-zinc-100"
+                  : "border-zinc-700 bg-transparent text-zinc-300 hover:border-indigo-400/50 hover:text-indigo-100"
+              )}
+            >
+              <FilterIcon className="h-3.5 w-3.5" />
+              {expandedPanels.filters ? "Nascondi filtri" : "Filtri rapidi"}
+            </button>
+            <button
+              type="button"
+              onClick={() => togglePanel("documents")}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition",
+                expandedPanels.documents
+                  ? "border-indigo-500/50 bg-indigo-500/10 text-indigo-100"
+                  : "border-zinc-700 bg-transparent text-zinc-300 hover:border-indigo-400/50 hover:text-indigo-100"
+              )}
+            >
+              <FileText className="h-3.5 w-3.5" />
+              {expandedPanels.documents ? "Riduci documenti" : "Documenti"}
+            </button>
+            <button
+              type="button"
+              onClick={() => togglePanel("inspector")}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition",
+                expandedPanels.inspector
+                  ? "border-indigo-500/50 bg-indigo-500/10 text-indigo-100"
+                  : "border-zinc-700 bg-transparent text-zinc-300 hover:border-indigo-400/50 hover:text-indigo-100",
+                !selectedEntry && "pointer-events-none opacity-40"
+              )}
+              disabled={!selectedEntry}
+            >
+              <Folder className="h-3.5 w-3.5" />
+              {expandedPanels.inspector ? "Chiudi dettagli" : "Dettagli documento"}
+            </button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              onClick={onRefresh}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
+                themeStyles?.input,
+                themeStyles?.input_hover,
+                loading && "opacity-70"
+              )}
+              disabled={loading}
+            >
+              <RefreshCw className={classNames("h-3.5 w-3.5", loading && "animate-spin")}
+              /> Aggiorna
+            </button>
+            <button
+              onClick={onAdoptSelection}
+              className={classNames(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
+                themeStyles?.button,
+                pipelineAligned && "ring-2 ring-emerald-400/70"
+              )}
+              disabled={!onAdoptSelection}
+            >
+              <Sparkles className="h-3.5 w-3.5" /> Usa nel form pipeline
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+          <span
+            className="inline-flex items-center gap-2 rounded-full border border-zinc-700/60 bg-zinc-900/60 px-3 py-1"
+            style={{ borderColor: workspaceBadgeColor }}
+          >
+            <span className="flex items-center gap-1 text-zinc-300">
+              <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: workspaceBadgeColor }} />
+              {workspaceBadgeLabel}
+            </span>
+          </span>
+          {projectBadgeLabel && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-indigo-500/40 bg-indigo-500/10 px-3 py-1 text-indigo-100">
+              <Folder className="h-3 w-3" /> {projectBadgeLabel}
+            </span>
+          )}
+          {statusBadgeLabel && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-fuchsia-500/40 bg-fuchsia-500/10 px-3 py-1 text-fuchsia-100">
+              <Sparkles className="h-3 w-3" /> {statusBadgeLabel}
+            </span>
+          )}
+          <span className="inline-flex items-center gap-1 rounded-full border border-zinc-700/60 bg-zinc-900/60 px-3 py-1">
+            <FileText className="h-3 w-3" /> {documentsCountLabel}
+          </span>
+          {searchActive && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-zinc-700/60 bg-zinc-900/60 px-3 py-1">
+              <FilterIcon className="h-3 w-3" /> Ricerca attiva
+            </span>
+          )}
+          {pipelineAligned && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/10 px-3 py-1 text-emerald-200">
+              <Sparkles className="h-3 w-3" /> Form sincronizzato
+            </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <input
-            value={filterName}
-            onChange={(event) => setFilterName(event.target.value)}
-            placeholder="Nome filtro"
-            className={classNames(
-              "w-36 rounded-xl border bg-transparent px-3 py-2 text-xs outline-none",
-              themeStyles?.input
-            )}
-          />
-          <button
-            onClick={handleFilterSave}
-            className={classNames(
-              "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
-              themeStyles?.button
-            )}
-          >
-            <Bookmark className="h-3.5 w-3.5" /> Salva filtro
-          </button>
-        </div>
       </div>
 
-      {savedFilters.length > 0 && (
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
-          {savedFilters.map((filter) => (
-            <span
-              key={filter.id}
-              className="inline-flex items-center gap-2 rounded-full border border-zinc-700/60 bg-zinc-900/60 px-3 py-1"
-            >
+      {expandedPanels.filters && (
+        <div className="space-y-4 border-b border-zinc-800/60 p-6">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="relative flex-1 min-w-[220px]">
+              <FilterIcon className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-zinc-500" />
+              <input
+                value={searchTerm}
+                onChange={(event) => onSearchChange?.(event.target.value)}
+                placeholder="Filtra per titolo, cliente, progetto o stato"
+                className={classNames(
+                  "w-full rounded-xl border bg-transparent px-9 py-2 text-sm outline-none",
+                  themeStyles?.input
+                )}
+              />
+              {searchTerm && (
+                <button
+                  onClick={() => onSearchChange?.("")}
+                  className="absolute right-2 top-2 rounded-lg px-2 py-1 text-xs text-zinc-400 hover:text-zinc-200"
+                >
+                  Pulisci
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                value={filterName}
+                onChange={(event) => setFilterName(event.target.value)}
+                placeholder="Nome filtro"
+                className={classNames(
+                  "w-36 rounded-xl border bg-transparent px-3 py-2 text-xs outline-none",
+                  themeStyles?.input
+                )}
+              />
               <button
-                onClick={() => onApplyFilter?.(filter)}
-                className="flex items-center gap-1 text-zinc-300 hover:text-white"
+                onClick={handleFilterSave}
+                className={classNames(
+                  "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
+                  themeStyles?.button
+                )}
               >
-                <LinkIcon className="h-3.5 w-3.5" /> {filter.name}
+                <Bookmark className="h-3.5 w-3.5" /> Salva filtro
               </button>
-              <button
-                onClick={() => onDeleteFilter?.(filter.id)}
-                className="text-zinc-500 hover:text-zinc-200"
-              >
-                <XCircle className="h-3.5 w-3.5" />
-              </button>
-            </span>
-          ))}
+            </div>
+          </div>
+
+          {savedFilters.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              {savedFilters.map((filter) => (
+                <span
+                  key={filter.id}
+                  className="inline-flex items-center gap-2 rounded-full border border-zinc-700/60 bg-zinc-900/60 px-3 py-1"
+                >
+                  <button
+                    onClick={() => onApplyFilter?.(filter)}
+                    className="flex items-center gap-1 text-zinc-300 hover:text-white"
+                  >
+                    <LinkIcon className="h-3.5 w-3.5" /> {filter.name}
+                  </button>
+                  <button
+                    onClick={() => onDeleteFilter?.(filter.id)}
+                    className="text-zinc-500 hover:text-zinc-200"
+                  >
+                    <XCircle className="h-3.5 w-3.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+            {breadcrumbs.map((crumb, index) => (
+              <React.Fragment key={`${crumb.label}-${index}`}>
+                {index > 0 && <ChevronRight className="h-3 w-3 text-zinc-600" />}
+                <span className="inline-flex items-center gap-1">
+                  <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: crumb.color || "#6366f1" }} />
+                  <span>{crumb.label}</span>
+                </span>
+              </React.Fragment>
+            ))}
+          </div>
         </div>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-zinc-400">
-        {breadcrumbs.map((crumb, index) => (
-          <React.Fragment key={`${crumb.label}-${index}`}>
-            {index > 0 && <ChevronRight className="h-3 w-3 text-zinc-600" />}
-            <span className="inline-flex items-center gap-1">
-              <span
-                className="h-2.5 w-2.5 rounded-full"
-                style={{ backgroundColor: crumb.color || "#6366f1" }}
-              />
-              <span>{crumb.label}</span>
-            </span>
-          </React.Fragment>
-        ))}
-        {pipelineAligned && (
-          <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/10 px-2 py-0.5 text-emerald-200">
-            <Sparkles className="h-3 w-3" /> Form sincronizzato
-          </span>
-        )}
-      </div>
-
-      <div className="mt-6 grid gap-4 xl:grid-cols-[minmax(220px,260px)_minmax(220px,240px)_minmax(0,1fr)]">
-        <div className="space-y-2">
-          <div className="flex items-center justify-between text-xs text-zinc-400">
+      {expandedPanels.navigator && (
+        <div className="border-b border-zinc-800/60 p-6">
+          <div className="mb-3 flex items-center justify-between text-xs text-zinc-400">
             <span>Workspace</span>
             <button onClick={handleWorkspaceReset} className="text-zinc-500 hover:text-zinc-200">
               Mostra tutti
             </button>
           </div>
-          <div className="max-h-[320px] space-y-2 overflow-auto pr-1">
-            {workspaceCatalog.map((workspace) => {
-              const isActive = workspace.id === normalizedSelection.workspaceId;
-              return (
-                <button
-                  type="button"
-                  key={workspace.id}
-                  onClick={() => handleWorkspaceSelect(workspace.id)}
-                  className={classNames(
-                    "w-full rounded-xl border px-3 py-2 text-left text-sm transition",
-                    themeStyles?.input,
-                    isActive && "border-indigo-400/70 ring-2 ring-indigo-400/30"
-                  )}
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="h-2.5 w-2.5 rounded-full"
-                        style={{ backgroundColor: workspace.color }}
-                      />
-                      <div>
-                        <div className="font-medium text-zinc-200">{workspace.name}</div>
-                        {workspace.client && (
-                          <div className="text-xs text-zinc-500">{workspace.client}</div>
-                        )}
-                      </div>
-                    </div>
-                    <div className="text-xs text-zinc-500">{workspace.count} doc</div>
-                  </div>
-                </button>
-              );
-            })}
-            {workspaceCatalog.length === 0 && (
-              <div className="rounded-xl border border-dashed border-zinc-700/60 p-3 text-xs text-zinc-500">
-                Nessun workspace ancora definito.
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <div className="rounded-xl border px-3 py-3 text-sm" style={{ borderColor: selectedWorkspace?.color || undefined }}>
-            <div className="flex items-center justify-between text-xs text-zinc-400">
-              <span className="flex items-center gap-1">
-                <Folder className="h-3.5 w-3.5" /> Progetti
-              </span>
-              {selectedWorkspace && (
-                <span className="flex items-center gap-1 text-[11px] text-zinc-500">
-                  <Palette className="h-3 w-3" /> {selectedWorkspace.client || "—"}
-                </span>
-              )}
-            </div>
-            {!normalizedSelection.workspaceId && (
-              <div className="mt-2 text-xs text-zinc-500">Seleziona un workspace per vedere i progetti.</div>
-            )}
-            {normalizedSelection.workspaceId === UNASSIGNED_KEY && (
-              <div className="mt-2 text-xs text-zinc-500">I documenti non assegnati non hanno progetti collegati.</div>
-            )}
-            {normalizedSelection.workspaceId && normalizedSelection.workspaceId !== UNASSIGNED_KEY && (
-              <div className="mt-2 flex flex-wrap gap-2">
-                <button
-                  onClick={() => handleProjectSelect({ key: "", name: "", id: "", statuses: [] })}
-                  className={classNames(
-                    "rounded-lg border px-3 py-1 text-xs",
-                    themeStyles?.input,
-                    !normalizedSelection.projectId && "border-indigo-400/70 text-indigo-200"
-                  )}
-                >
-                  Tutti
-                </button>
-                {projectCatalog.map((project) => {
-                  const isActive = project.key === normalizedSelection.projectId;
-                  return (
-                    <button
-                      type="button"
-                      key={project.key}
-                      onClick={() => handleProjectSelect(project)}
-                      className={classNames(
-                        "rounded-lg border px-3 py-1 text-xs transition",
-                        themeStyles?.input,
-                        isActive && "border-indigo-400/70 text-indigo-200"
-                      )}
-                    >
-                      <span className="font-medium">{project.name}</span>
-                      <span className="ml-2 text-[10px] text-zinc-500">{project.count} doc</span>
-                    </button>
-                  );
-                })}
-                {projectCatalog.length === 0 && (
-                  <div className="text-xs text-zinc-500">Nessun progetto registrato.</div>
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-xl border px-3 py-3 text-sm">
-            <div className="flex items-center justify-between text-xs text-zinc-400">
-              <span>Stato</span>
-              {normalizedSelection.status && (
-                <button
-                  onClick={() => handleStatusSelect("")}
-                  className="text-zinc-500 hover:text-zinc-200"
-                >
-                  Azzera
-                </button>
-              )}
-            </div>
-            <div className="mt-2 flex flex-wrap gap-2">
-              {statusCatalog.map((status) => {
-                const isActive = status.label === normalizedSelection.status;
+          <div className="grid gap-4 lg:grid-cols-[minmax(220px,260px)_minmax(0,1fr)]">
+            <div className="max-h-[320px] space-y-2 overflow-auto pr-1">
+              {workspaceCatalog.map((workspace) => {
+                const isActive = workspace.id === normalizedSelection.workspaceId;
                 return (
                   <button
                     type="button"
-                    key={status.label}
-                    onClick={() => handleStatusSelect(status.label)}
+                    key={workspace.id}
+                    onClick={() => handleWorkspaceSelect(workspace.id)}
                     className={classNames(
-                      "rounded-full border px-3 py-1 text-xs",
-                      themeStyles?.input,
-                      isActive && "border-indigo-400/70 text-indigo-200"
-                    )}
-                  >
-                    {status.label}
-                    {Number.isFinite(status.count) && status.count > 0 && (
-                      <span className="ml-2 text-[10px] text-zinc-500">{status.count}</span>
-                    )}
-                  </button>
-                );
-              })}
-              {statusCatalog.length === 0 && (
-                <div className="text-xs text-zinc-500">Nessuno stato disponibile.</div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <div className="rounded-xl border px-3 py-3">
-            <div className="flex items-center justify-between text-xs text-zinc-400">
-              <span>Documenti</span>
-              <span>{filteredEntries.length} risultati</span>
-            </div>
-            <div className="mt-2 max-h-[320px] space-y-2 overflow-auto pr-1">
-              {filteredEntries.length === 0 && (
-                <div className="rounded-xl border border-dashed border-zinc-700/60 p-4 text-sm text-zinc-500">
-                  Nessun documento corrispondente ai filtri selezionati.
-                </div>
-              )}
-              {filteredEntries.map((entry) => {
-                const isActive = selectedEntry?.id === entry.id;
-                const completeness = formatCompleteness(entry?.completenessScore);
-                const entryProjectKey = computeProjectKey(entry?.workspace?.projectId, entry?.workspace?.projectName);
-                return (
-                  <button
-                    type="button"
-                    key={entry.id}
-                    onClick={() => setSelectedEntryId(entry.id)}
-                    className={classNames(
-                      "w-full rounded-xl border px-4 py-3 text-left text-sm transition",
+                      "w-full rounded-xl border px-3 py-2 text-left text-sm transition",
                       themeStyles?.input,
                       isActive && "border-indigo-400/70 ring-2 ring-indigo-400/30"
                     )}
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-1">
-                        <div className="flex items-center gap-2 text-zinc-200">
-                          <FileText className="h-4 w-4" />
-                          <span className="font-medium">{entry?.title || entry?.slug || "Documento"}</span>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500">
-                          <span>{formatTimestamp(entry?.timestamp)}</span>
-                          {entryProjectKey && (
-                            <span className="rounded-lg bg-zinc-800/70 px-2 py-0.5 text-[10px] uppercase tracking-wide">
-                              {entry?.workspace?.projectName || entry?.workspace?.projectId || "Progetto"}
-                            </span>
-                          )}
-                          {entry?.workspace?.status && (
-                            <span className="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2 py-0.5 text-[10px] text-indigo-200">
-                              {entry.workspace.status}
-                            </span>
-                          )}
-                          {entry?.prompt?.title && (
-                            <span className="flex items-center gap-1 rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2 py-0.5 text-[10px] text-indigo-200">
-                              <Sparkles className="h-3 w-3" />
-                              {entry.prompt.title}
-                            </span>
-                          )}
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex items-center gap-2">
+                        <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: workspace.color }} />
+                        <div>
+                          <div className="font-medium text-zinc-200">{workspace.name}</div>
+                          {workspace.client && <div className="text-xs text-zinc-500">{workspace.client}</div>}
                         </div>
                       </div>
-                      <div className="text-right text-xs text-zinc-400">
-                        {Number.isFinite(completeness) ? (
-                          <div>
-                            <div className="text-sm font-semibold text-indigo-200">{completeness}%</div>
-                            <div>completezza</div>
-                          </div>
-                        ) : (
-                          <div className="text-zinc-600">—</div>
-                        )}
-                      </div>
+                      <div className="text-xs text-zinc-500">{workspace.count} doc</div>
                     </div>
-                    {Array.isArray(entry?.structure?.missingSections) && entry.structure.missingSections.length > 0 && (
-                      <div className="mt-2 text-xs text-amber-300">
-                        Manca: {entry.structure.missingSections.join(", ")}
-                      </div>
-                    )}
-                    {entry?.structure?.promptChecklist?.missing?.length > 0 && (
-                      <div className="mt-1 text-xs text-amber-300">
-                        Gap template: {entry.structure.promptChecklist.missing.join(", ")}
-                      </div>
-                    )}
                   </button>
                 );
               })}
-            </div>
-          </div>
-
-          <div className="rounded-xl border px-4 py-4">
-            {selectedEntry ? (
-              <div className="space-y-3">
-                <div>
-                  <div className="text-sm font-semibold text-zinc-100">{selectedEntry.title || selectedEntry.slug || "Documento"}</div>
-                  <div className="text-xs text-zinc-500">{selectedEntry.workspace?.client || selectedEntry.workspace?.name || ""}</div>
+              {workspaceCatalog.length === 0 && (
+                <div className="rounded-xl border border-dashed border-zinc-700/60 p-3 text-xs text-zinc-500">
+                  Nessun workspace ancora definito.
                 </div>
-                <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
-                  <span>ID: {selectedEntry.id}</span>
-                  {selectedEntry.workspace?.projectName && (
-                    <span className="rounded-lg bg-zinc-800/60 px-2 py-0.5">{selectedEntry.workspace.projectName}</span>
-                  )}
-                  {selectedEntry.workspace?.status && (
-                    <span className="rounded-lg border border-indigo-500/40 px-2 py-0.5 text-indigo-200">
-                      {selectedEntry.workspace.status}
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="rounded-xl border px-3 py-3 text-sm" style={{ borderColor: selectedWorkspace?.color || undefined }}>
+                <div className="flex items-center justify-between text-xs text-zinc-400">
+                  <span className="flex items-center gap-1">
+                    <Folder className="h-3.5 w-3.5" /> Progetti
+                  </span>
+                  {selectedWorkspace && (
+                    <span className="flex items-center gap-1 text-[11px] text-zinc-500">
+                      <Palette className="h-3 w-3" /> {selectedWorkspace.client || "—"}
                     </span>
                   )}
                 </div>
-                {selectedEntry.prompt?.title && (
-                  <div className="rounded-lg border border-indigo-500/30 bg-indigo-500/10 p-3 text-xs text-indigo-100 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Sparkles className="h-3.5 w-3.5" />
-                      <span className="text-sm font-semibold text-indigo-100">{selectedEntry.prompt.title}</span>
-                    </div>
-                    {selectedEntry.prompt.persona && (
-                      <div className="text-[11px] text-indigo-200/80">Persona: {selectedEntry.prompt.persona}</div>
-                    )}
-                    {Array.isArray(selectedEntry.prompt.tags) && selectedEntry.prompt.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {selectedEntry.prompt.tags.map((tag) => (
-                          <span
-                            key={tag}
-                            className="rounded-lg bg-black/30 px-2 py-0.5 text-[10px] uppercase tracking-wide text-indigo-200/80"
-                          >
-                            #{tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {Number.isFinite(selectedEntry.structure?.promptChecklist?.score) && (
-                      <div className="text-[11px] text-indigo-200/80">
-                        Copertura template: {Math.round(selectedEntry.structure.promptChecklist.score)}%
-                      </div>
-                    )}
-                    {selectedEntry.structure?.promptChecklist?.missing?.length > 0 && (
-                      <div className="text-[11px] text-amber-200">
-                        Gap: {selectedEntry.structure.promptChecklist.missing.join(', ')}
-                      </div>
-                    )}
-                    {selectedEntry.prompt?.focus && (
-                      <div className="text-[11px] text-indigo-200/80">Focus: {selectedEntry.prompt.focus}</div>
-                    )}
-                    {selectedEntry.prompt?.notes && (
-                      <div className="text-[11px] text-indigo-200/70">Note: {selectedEntry.prompt.notes}</div>
-                    )}
-                    {Array.isArray(selectedEntry.prompt?.completedCues) && selectedEntry.prompt.completedCues.length > 0 && (
-                      <div className="text-[11px] text-indigo-200/70">
-                        Cue completate: {selectedEntry.prompt.completedCues.join(', ')}
-                      </div>
-                    )}
+                {!normalizedSelection.workspaceId && (
+                  <div className="mt-2 text-xs text-zinc-500">Seleziona un workspace per vedere i progetti.</div>
+                )}
+                {normalizedSelection.workspaceId === UNASSIGNED_KEY && (
+                  <div className="mt-2 text-xs text-zinc-500">I documenti non assegnati non hanno progetti collegati.</div>
+                )}
+                {normalizedSelection.workspaceId && normalizedSelection.workspaceId !== UNASSIGNED_KEY && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      onClick={() => handleProjectSelect({ key: "", name: "", id: "", statuses: [] })}
+                      className={classNames(
+                        "rounded-lg border px-3 py-1 text-xs",
+                        themeStyles?.input,
+                        !normalizedSelection.projectId && "border-indigo-400/70 text-indigo-200"
+                      )}
+                    >
+                      Tutti
+                    </button>
+                    {projectCatalog.map((project) => {
+                      const isActive = project.key === normalizedSelection.projectId;
+                      return (
+                        <button
+                          type="button"
+                          key={project.key}
+                          onClick={() => handleProjectSelect(project)}
+                          className={classNames(
+                            "rounded-lg border px-3 py-1 text-xs transition",
+                            themeStyles?.input,
+                            isActive && "border-indigo-400/70 text-indigo-200"
+                          )}
+                        >
+                          <span className="font-medium">{project.name}</span>
+                          <span className="ml-2 text-[10px] text-zinc-500">{project.count} doc</span>
+                        </button>
+                      );
+                    })}
+                    {projectCatalog.length === 0 && <div className="text-xs text-zinc-500">Nessun progetto registrato.</div>}
                   </div>
                 )}
-                <div className="max-h-48 overflow-auto rounded-lg border border-zinc-800/60 bg-black/20 p-3 text-sm text-zinc-200">
-                  {previewState.loading ? (
-                    <div className="text-xs text-zinc-500">Caricamento anteprima…</div>
-                  ) : previewState.error ? (
-                    <div className="text-xs text-rose-300">{previewState.error}</div>
-                  ) : previewState.markdown ? (
-                    <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed text-zinc-200">
-                      {previewState.markdown}
-                    </pre>
-                  ) : (
-                    <div className="text-xs text-zinc-500">Anteprima non disponibile.</div>
-                  )}
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    onClick={() => onOpenPdf?.(selectedEntry)}
-                    className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" /> Apri PDF
-                  </button>
-                  <button
-                    onClick={() => onOpenMd?.(selectedEntry)}
-                    className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
-                  >
-                    <FileText className="h-3.5 w-3.5" /> Apri MD
-                  </button>
-                  <button
-                    onClick={() => onRepublish?.(selectedEntry)}
-                    className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
-                  >
-                    <Sparkles className="h-3.5 w-3.5" /> Rigenera PDF
-                  </button>
-                  <button
-                    onClick={() => onShowLogs?.(selectedEntry)}
-                    className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.input, themeStyles?.input_hover)}
-                  >
-                    <Folder className="h-3.5 w-3.5" /> Log pipeline
-                  </button>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 text-xs">
-                  {workspaceAssignment && (
-                    <button
-                      onClick={handleAssign}
-                      className={classNames(
-                        "flex items-center gap-2 rounded-lg px-3 py-2",
-                        themeStyles?.button,
-                        assigning && "opacity-70"
-                      )}
-                      disabled={assigning || !canAssign}
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      {canAssign ? "Allinea al workspace" : "Workspace allineato"}
+              </div>
+
+              <div className="rounded-xl border px-3 py-3 text-sm">
+                <div className="flex items-center justify-between text-xs text-zinc-400">
+                  <span>Stato</span>
+                  {normalizedSelection.status && (
+                    <button onClick={() => handleStatusSelect("")} className="text-zinc-500 hover:text-zinc-200">
+                      Azzera
                     </button>
                   )}
-                  {canUnassign && (
-                    <button
-                      onClick={handleUnassign}
-                      className={classNames(
-                        "flex items-center gap-2 rounded-lg px-3 py-2",
-                        themeStyles?.input,
-                        themeStyles?.input_hover,
-                        assigning && "opacity-70"
-                      )}
-                      disabled={assigning}
-                    >
-                      <XCircle className="h-3.5 w-3.5" /> Rimuovi workspace
-                    </button>
-                  )}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {statusCatalog.map((status) => {
+                    const isActive = status.label === normalizedSelection.status;
+                    return (
+                      <button
+                        type="button"
+                        key={status.label}
+                        onClick={() => handleStatusSelect(status.label)}
+                        className={classNames(
+                          "rounded-full border px-3 py-1 text-xs",
+                          themeStyles?.input,
+                          isActive && "border-indigo-400/70 text-indigo-200"
+                        )}
+                      >
+                        {status.label}
+                        {Number.isFinite(status.count) && status.count > 0 && (
+                          <span className="ml-2 text-[10px] text-zinc-500">{status.count}</span>
+                        )}
+                      </button>
+                    );
+                  })}
+                  {statusCatalog.length === 0 && <div className="text-xs text-zinc-500">Nessuno stato disponibile.</div>}
                 </div>
               </div>
-            ) : (
-              <div className="text-sm text-zinc-500">Seleziona un documento per visualizzare l'anteprima.</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {expandedPanels.documents && (
+        <div className="p-6">
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-400">
+            <span className="flex items-center gap-2">
+              <FileText className="h-3.5 w-3.5" /> Catalogo documenti
+            </span>
+            <span>{filteredEntries.length} risultati</span>
+          </div>
+          <div
+            className={classNames(
+              "mt-3 grid gap-4",
+              expandedPanels.inspector ? "lg:grid-cols-[minmax(240px,320px)_minmax(0,1fr)]" : "lg:grid-cols-1"
+            )}
+          >
+            <div className="rounded-xl border px-3 py-3">
+              <div className="max-h-[320px] space-y-2 overflow-auto pr-1">
+                {filteredEntries.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-zinc-700/60 p-4 text-sm text-zinc-500">
+                    Nessun documento corrispondente ai filtri selezionati.
+                  </div>
+                )}
+                {filteredEntries.map((entry) => {
+                  const isActive = selectedEntry?.id === entry.id;
+                  const completeness = formatCompleteness(entry?.completenessScore);
+                  const entryProjectKey = computeProjectKey(entry?.workspace?.projectId, entry?.workspace?.projectName);
+                  return (
+                    <button
+                      type="button"
+                      key={entry.id}
+                      onClick={() => setSelectedEntryId(entry.id)}
+                      className={classNames(
+                        "w-full rounded-xl border px-4 py-3 text-left text-sm transition",
+                        themeStyles?.input,
+                        isActive && "border-indigo-400/70 ring-2 ring-indigo-400/30"
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2 text-zinc-200">
+                            <FileText className="h-4 w-4" />
+                            <span className="font-medium">{entry?.title || entry?.slug || "Documento"}</span>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+                            <span>{formatTimestamp(entry?.timestamp)}</span>
+                            {entryProjectKey && (
+                              <span className="rounded-lg bg-zinc-800/70 px-2 py-0.5 text-[10px] uppercase tracking-wide">
+                                {entry?.workspace?.projectName || entry?.workspace?.projectId || "Progetto"}
+                              </span>
+                            )}
+                            {entry?.workspace?.status && (
+                              <span className="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2 py-0.5 text-[10px] text-indigo-200">
+                                {entry.workspace.status}
+                              </span>
+                            )}
+                            {entry?.prompt?.title && (
+                              <span className="flex items-center gap-1 rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2 py-0.5 text-[10px] text-indigo-200">
+                                <Sparkles className="h-3 w-3" />
+                                {entry.prompt.title}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="text-right text-xs text-zinc-400">
+                          {Number.isFinite(completeness) ? (
+                            <div>
+                              <div className="text-sm font-semibold text-indigo-200">{completeness}%</div>
+                              <div>completezza</div>
+                            </div>
+                          ) : (
+                            <div className="text-zinc-600">—</div>
+                          )}
+                        </div>
+                      </div>
+                      {Array.isArray(entry?.structure?.missingSections) && entry.structure.missingSections.length > 0 && (
+                        <div className="mt-2 text-xs text-amber-300">
+                          Manca: {entry.structure.missingSections.join(", ")}
+                        </div>
+                      )}
+                      {entry?.structure?.promptChecklist?.missing?.length > 0 && (
+                        <div className="mt-1 text-xs text-amber-300">
+                          Gap template: {entry.structure.promptChecklist.missing.join(", ")}
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {expandedPanels.inspector && (
+              <div className="rounded-xl border px-4 py-4">
+                {selectedEntry ? (
+                  <div className="space-y-3">
+                    <div>
+                      <div className="text-sm font-semibold text-zinc-100">{selectedEntry.title || selectedEntry.slug || "Documento"}</div>
+                      <div className="text-xs text-zinc-500">{selectedEntry.workspace?.client || selectedEntry.workspace?.name || ""}</div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+                      <span>ID: {selectedEntry.id}</span>
+                      {selectedEntry.workspace?.projectName && (
+                        <span className="rounded-lg bg-zinc-800/60 px-2 py-0.5">{selectedEntry.workspace.projectName}</span>
+                      )}
+                      {selectedEntry.workspace?.status && (
+                        <span className="rounded-lg border border-indigo-500/40 px-2 py-0.5 text-indigo-200">
+                          {selectedEntry.workspace.status}
+                        </span>
+                      )}
+                    </div>
+                    {selectedEntry.prompt?.title && (
+                      <div className="space-y-2 rounded-lg border border-indigo-500/30 bg-indigo-500/10 p-3 text-xs text-indigo-100">
+                        <div className="flex items-center gap-2">
+                          <Sparkles className="h-3.5 w-3.5" />
+                          <span className="text-sm font-semibold text-indigo-100">{selectedEntry.prompt.title}</span>
+                        </div>
+                        {selectedEntry.prompt.persona && (
+                          <div className="text-[11px] text-indigo-200/80">Persona: {selectedEntry.prompt.persona}</div>
+                        )}
+                        {Array.isArray(selectedEntry.prompt.tags) && selectedEntry.prompt.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {selectedEntry.prompt.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="rounded-lg bg-black/30 px-2 py-0.5 text-[10px] uppercase tracking-wide text-indigo-200/80"
+                              >
+                                #{tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        {Number.isFinite(selectedEntry.structure?.promptChecklist?.score) && (
+                          <div className="text-[11px] text-indigo-200/80">
+                            Copertura template: {Math.round(selectedEntry.structure.promptChecklist.score)}%
+                          </div>
+                        )}
+                        {selectedEntry.structure?.promptChecklist?.missing?.length > 0 && (
+                          <div className="text-[11px] text-amber-200">
+                            Gap: {selectedEntry.structure.promptChecklist.missing.join(', ')}
+                          </div>
+                        )}
+                        {selectedEntry.prompt?.focus && (
+                          <div className="text-[11px] text-indigo-200/80">Focus: {selectedEntry.prompt.focus}</div>
+                        )}
+                        {selectedEntry.prompt?.notes && (
+                          <div className="text-[11px] text-indigo-200/70">Note: {selectedEntry.prompt.notes}</div>
+                        )}
+                        {Array.isArray(selectedEntry.prompt?.completedCues) && selectedEntry.prompt.completedCues.length > 0 && (
+                          <div className="text-[11px] text-indigo-200/70">
+                            Cue completate: {selectedEntry.prompt.completedCues.join(', ')}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    <div className="max-h-48 overflow-auto rounded-lg border border-zinc-800/60 bg-black/20 p-3 text-sm text-zinc-200">
+                      {previewState.loading ? (
+                        <div className="text-xs text-zinc-500">Caricamento anteprima…</div>
+                      ) : previewState.error ? (
+                        <div className="text-xs text-rose-300">{previewState.error}</div>
+                      ) : previewState.markdown ? (
+                        <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed text-zinc-200">
+                          {previewState.markdown}
+                        </pre>
+                      ) : (
+                        <div className="text-xs text-zinc-500">Anteprima non disponibile.</div>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        onClick={() => onOpenPdf?.(selectedEntry)}
+                        className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" /> Apri PDF
+                      </button>
+                      <button
+                        onClick={() => onOpenMd?.(selectedEntry)}
+                        className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
+                      >
+                        <FileText className="h-3.5 w-3.5" /> Apri MD
+                      </button>
+                      <button
+                        onClick={() => onRepublish?.(selectedEntry)}
+                        className={classNames("flex items-center gap-2 rounded-lg px-3 py-2 text-xs", themeStyles?.button)}
+                      >
+                        <Sparkles className="h-3.5 w-3.5" /> Rigenera PDF
+                      </button>
+                      <button
+                        onClick={() => onShowLogs?.(selectedEntry)}
+                        className={classNames(
+                          "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
+                          themeStyles?.input,
+                          themeStyles?.input_hover
+                        )}
+                      >
+                        <Folder className="h-3.5 w-3.5" /> Log pipeline
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      {workspaceAssignment && (
+                        <button
+                          onClick={handleAssign}
+                          className={classNames(
+                            "flex items-center gap-2 rounded-lg px-3 py-2",
+                            themeStyles?.button,
+                            assigning && "opacity-70"
+                          )}
+                          disabled={assigning || !canAssign}
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                          {canAssign ? "Allinea al workspace" : "Workspace allineato"}
+                        </button>
+                      )}
+                      {canUnassign && (
+                        <button
+                          onClick={handleUnassign}
+                          className={classNames(
+                            "flex items-center gap-2 rounded-lg px-3 py-2",
+                            themeStyles?.input,
+                            themeStyles?.input_hover,
+                            assigning && "opacity-70"
+                          )}
+                          disabled={assigning}
+                        >
+                          <XCircle className="h-3.5 w-3.5" /> Rimuovi workspace
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-sm text-zinc-500">Seleziona un documento per visualizzare l'anteprima.</div>
+                )}
+              </div>
             )}
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- introduce collapsible sections for the prompt library to keep the interface minimal by default
- add contextual header messaging and quick status of the active template
- reorganize builder, filters, and actions inside the expandable panel for a more modern interaction pattern
- mirror the collapsible minimal pattern in the workspace navigator card, restoring helper logic and surfacing compact status badges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1720be2f083209e9f98fc322d7374