### PR TITLE
Align upload card labels

### DIFF
--- a/rec2pdf-frontend/src/App.jsx
+++ b/rec2pdf-frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Mic, Square, Settings, Folder, FileText, FileCode, Cpu, Download, TimerIcon, Waves, CheckCircle2, AlertCircle, LinkIcon, Upload, RefreshCw, Bug, XCircle, Info, Maximize, Sparkles, Plus, Users } from "./components/icons";
+import { Mic, Square, Settings, Folder, FileText, FileCode, Cpu, Download, TimerIcon, Waves, CheckCircle2, AlertCircle, LinkIcon, Upload, RefreshCw, Bug, XCircle, Info, Maximize, Sparkles, Plus, Users, ChevronRight } from "./components/icons";
 import logo from './assets/logo.svg';
 import SetupAssistant from "./components/SetupAssistant";
 import { useMicrophoneAccess } from "./hooks/useMicrophoneAccess";
@@ -342,6 +342,7 @@ export default function Rec2PdfApp(){
   const [elapsed,setElapsed]=useState(0);
   const [level,setLevel]=useState(0);
   const [audioBlob,setAudioBlob]=useState(null);
+  const [audioSectionOpen, setAudioSectionOpen] = useState(true);
   const [audioUrl,setAudioUrl]=useState("");
   const [mime,setMime]=useState("");
   const [destDir,setDestDir]=useState("/Users/tuo_utente/Recordings");
@@ -2802,13 +2803,67 @@ export default function Rec2PdfApp(){
               onDeletePrompt={handleDeletePrompt}
             />
             <div className={classNames("mt-6 rounded-xl p-4 border", themes[theme].input)}>
-              <div className="flex items-center justify-between"><div className="text-sm text-zinc-400">Clip registrata / caricata</div><div className="text-xs text-zinc-500">{mime||"—"} · {fmtBytes(audioBlob?.size)}</div></div>
-              <div className="mt-3">{audioUrl?<audio controls src={audioUrl} className="w-full"/>:<div className="text-zinc-500 text-sm">Nessuna clip disponibile.</div>}</div>
-              <div className="mt-3 flex items-center gap-2 flex-wrap">
-                <button onClick={()=>processViaBackend()} disabled={!audioBlob||busy||backendUp===false} className={classNames("px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm font-medium flex items-center gap-2",(!audioBlob||busy||backendUp===false)&&"opacity-60 cursor-not-allowed")}> <Cpu className="w-4 h-4"/> Avvia pipeline</button>
-                <a href={audioUrl} download={`recording.${((mime||"").includes("webm")?"webm":(mime||"").includes("ogg")?"ogg":(mime||"").includes("wav")?"wav":"m4a")}`} className={classNames("px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2", themes[theme].button, !audioUrl&&"pointer-events-none opacity-50")}> <Download className="w-4 h-4"/> Scarica audio</a>
-                <button onClick={resetAll} className={classNames("px-4 py-2 rounded-lg text-sm", themes[theme].button)}>Reset</button>
-              </div>
+              <button
+                type="button"
+                onClick={() => setAudioSectionOpen((prev) => !prev)}
+                className="w-full flex items-center justify-between text-left"
+                aria-expanded={audioSectionOpen}
+              >
+                <div className="flex items-center gap-2 text-sm text-zinc-400">
+                  <ChevronRight
+                    className={classNames(
+                      "w-4 h-4 transition-transform",
+                      audioSectionOpen && "rotate-90"
+                    )}
+                  />
+                  <span>Clip registrata / caricata</span>
+                </div>
+                <div className="text-xs text-zinc-500 flex items-center gap-1">
+                  <span>{mime || "—"}</span>
+                  <span>·</span>
+                  <span>{fmtBytes(audioBlob?.size)}</span>
+                </div>
+              </button>
+              {audioSectionOpen && (
+                <>
+                  <div className="mt-3">
+                    {audioUrl ? (
+                      <audio controls src={audioUrl} className="w-full" />
+                    ) : (
+                      <div className="text-zinc-500 text-sm">Nessuna clip disponibile.</div>
+                    )}
+                  </div>
+                  <div className="mt-3 flex items-center gap-2 flex-wrap">
+                    <button
+                      onClick={() => processViaBackend()}
+                      disabled={!audioBlob || busy || backendUp === false}
+                      className={classNames(
+                        "px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm font-medium flex items-center gap-2",
+                        (!audioBlob || busy || backendUp === false) && "opacity-60 cursor-not-allowed"
+                      )}
+                    >
+                      <Cpu className="w-4 h-4" /> Avvia pipeline
+                    </button>
+                    <a
+                      href={audioUrl}
+                      download={`recording.${((mime||"").includes("webm")?"webm":(mime||"").includes("ogg")?"ogg":(mime||"").includes("wav")?"wav":"m4a")}`}
+                      className={classNames(
+                        "px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2",
+                        themes[theme].button,
+                        !audioUrl && "pointer-events-none opacity-50"
+                      )}
+                    >
+                      <Download className="w-4 h-4" /> Scarica audio
+                    </a>
+                    <button
+                      onClick={resetAll}
+                      className={classNames("px-4 py-2 rounded-lg text-sm", themes[theme].button)}
+                    >
+                      Reset
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               <div className={classNames("rounded-2xl border p-5 space-y-4 transition-all", themes[theme].input)}>
@@ -2832,18 +2887,7 @@ export default function Rec2PdfApp(){
                     type="button"
                   >
                     <Upload className="w-4 h-4" />
-                    Seleziona audio
-                  </button>
-                  <button
-                    onClick={() => processViaBackend(audioBlob)}
-                    disabled={!audioBlob || busy || backendUp === false}
-                    className={classNames(
-                      "px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-500 transition",
-                      (!audioBlob || busy || backendUp === false) && "opacity-60 cursor-not-allowed"
-                    )}
-                    type="button"
-                  >
-                    Invia al backend
+                    Seleziona file audio
                   </button>
                 </div>
                 {audioBlob && (
@@ -2870,7 +2914,7 @@ export default function Rec2PdfApp(){
                     <FileCode className="w-4 h-4" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-semibold text-zinc-100">Markdown pronto</h4>
+                    <h4 className="text-sm font-semibold text-zinc-100">Carica Markdown</h4>
                     <p className="text-xs text-zinc-400">Carica un documento .md già strutturato per impaginarlo subito con PPUBR.</p>
                   </div>
                 </div>
@@ -2887,7 +2931,7 @@ export default function Rec2PdfApp(){
                     type="button"
                   >
                     <Upload className="w-4 h-4" />
-                    Seleziona Markdown
+                    Seleziona file Markdown
                   </button>
                   {lastMarkdownUpload && (
                     <div className="text-xs text-zinc-500 flex items-center gap-2">
@@ -2905,7 +2949,7 @@ export default function Rec2PdfApp(){
                     <FileText className="w-4 h-4" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-semibold text-zinc-100">Testo semplice</h4>
+                    <h4 className="text-sm font-semibold text-zinc-100">Carica TXT</h4>
                     <p className="text-xs text-zinc-400">Carica un file .txt: lo convertiamo in Markdown e avviamo l&apos;impaginazione.</p>
                   </div>
                 </div>
@@ -2922,7 +2966,7 @@ export default function Rec2PdfApp(){
                     type="button"
                   >
                     <Upload className="w-4 h-4" />
-                    Seleziona testo
+                    Seleziona file TXT
                   </button>
                   {lastTextUpload && (
                     <div className="text-xs text-zinc-500 flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove the redundant backend submission button from the audio upload card so all flows rely on the main pipeline action
- rename the three upload cards and their actions to use consistent "Carica" phrasing across audio, Markdown, and TXT inputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e20fee3aa483209e121e8134d56a4e