### PR TITLE
Standardize upload card titles

### DIFF
--- a/rec2pdf-frontend/src/App.jsx
+++ b/rec2pdf-frontend/src/App.jsx
@@ -2865,7 +2865,7 @@ export default function Rec2PdfApp(){
                     <FileCode className="w-4 h-4" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-semibold text-zinc-100">Markdown pronto</h4>
+                    <h4 className="text-sm font-semibold text-zinc-100">Carica Markdown</h4>
                     <p className="text-xs text-zinc-400">Carica un documento .md già strutturato per impaginarlo subito con PPUBR.</p>
                   </div>
                 </div>
@@ -2900,7 +2900,7 @@ export default function Rec2PdfApp(){
                     <FileText className="w-4 h-4" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-semibold text-zinc-100">Testo semplice</h4>
+                    <h4 className="text-sm font-semibold text-zinc-100">Carica TXT</h4>
                     <p className="text-xs text-zinc-400">Carica un file .txt: lo convertiamo in Markdown e avviamo l&apos;impaginazione.</p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- rename the Markdown upload card title to "Carica Markdown"
- rename the plain text upload card title to "Carica TXT"

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e2b9b16c78832084c787277b944d1a